### PR TITLE
UiDropdown1 из темы @vue/cli

### DIFF
--- a/04-vue-cli/03-UiDropdown1/__tests__/UiDropdown1.test.js
+++ b/04-vue-cli/03-UiDropdown1/__tests__/UiDropdown1.test.js
@@ -147,8 +147,6 @@ describe('vue-cli/UiDropdown1', () => {
 
     // Раскомментируйте блок ниже, если решаете дополнительную часть задачи
 
-    /*
-
     it('UiDropdown должен иметь <select> со списком вариантов <option> в соответствии с параметром options', () => {
       const wrapper = mount(UiDropdown, {
         props: { options: OPTIONS, title: TITLE },
@@ -180,7 +178,5 @@ describe('vue-cli/UiDropdown1', () => {
       expect(wrapper.emitted('update:modelValue').length).toBe(1);
       expect(wrapper.emitted('update:modelValue')[0]).toEqual([OPTIONS[1].value]);
     });
-
-     */
   });
 });

--- a/04-vue-cli/03-UiDropdown1/components/UiDropdown.vue
+++ b/04-vue-cli/03-UiDropdown1/components/UiDropdown.vue
@@ -25,6 +25,7 @@
       </button>
     </div>
   </div>
+
   <select v-show="false" :value="modelValue" @change="$emit('update:modelValue', $event.target.value)">
     <option v-for="item in options" :key="item" :value="item.value">{{ item.text }}</option>
   </select>
@@ -71,8 +72,7 @@ export default {
       return this.options.find((item) => this.modelValue == item.value);
     },
     optionsHasIcon() {
-      const ret = this.options.some((item) => !!item.icon);
-      return ret;
+      return this.options.some((item) => !!item.icon);
     },
   },
 

--- a/04-vue-cli/03-UiDropdown1/components/UiDropdown.vue
+++ b/04-vue-cli/03-UiDropdown1/components/UiDropdown.vue
@@ -1,21 +1,33 @@
 <template>
-  <div class="dropdown dropdown_opened">
-    <button type="button" class="dropdown__toggle dropdown__toggle_icon">
-      <ui-icon icon="tv" class="dropdown__icon" />
-      <span>Title</span>
+  <div class="dropdown" :class="{ dropdown_opened: showedList }">
+    <button
+      type="button"
+      class="dropdown__toggle"
+      :class="{ dropdown__toggle_icon: optionsHasIcon }"
+      @click="switchList"
+    >
+      <ui-icon v-if="selectedIcon" :icon="selectedIcon" class="dropdown__icon" />
+      <span>{{ selectedTitle }}</span>
     </button>
 
-    <div class="dropdown__menu" role="listbox">
-      <button class="dropdown__item dropdown__item_icon" role="option" type="button">
-        <ui-icon icon="tv" class="dropdown__icon" />
-        Option 1
-      </button>
-      <button class="dropdown__item dropdown__item_icon" role="option" type="button">
-        <ui-icon icon="tv" class="dropdown__icon" />
-        Option 2
+    <div v-show="showedList" class="dropdown__menu" role="listbox">
+      <button
+        v-for="item in options"
+        :key="item"
+        class="dropdown__item"
+        :class="{ dropdown__item_icon: optionsHasIcon }"
+        role="option"
+        type="button"
+        @click="selectValue(item.value)"
+      >
+        <ui-icon v-if="item.icon" :icon="item.icon" class="dropdown__icon" />
+        {{ item.text }}
       </button>
     </div>
   </div>
+  <select v-show="false" :value="modelValue" @change="$emit('update:modelValue', $event.target.value)">
+    <option v-for="item in options" :key="item" :value="item.value">{{ item.text }}</option>
+  </select>
 </template>
 
 <script>
@@ -25,6 +37,55 @@ export default {
   name: 'UiDropdown',
 
   components: { UiIcon },
+
+  props: {
+    options: {
+      type: Array,
+      required: true,
+    },
+    modelValue: {
+      type: String,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+  },
+
+  emits: ['update:modelValue'],
+
+  data() {
+    return {
+      showedList: false,
+    };
+  },
+
+  computed: {
+    selectedTitle() {
+      return this.currentOption ? this.currentOption.text : this.title;
+    },
+    selectedIcon() {
+      return this.currentOption ? this.currentOption.icon : null;
+    },
+    currentOption() {
+      return this.options.find((item) => this.modelValue == item.value);
+    },
+    optionsHasIcon() {
+      const ret = this.options.some((item) => !!item.icon);
+      return ret;
+    },
+  },
+
+  methods: {
+    switchList() {
+      this.showedList = !this.showedList;
+    },
+
+    selectValue(value) {
+      this.$emit('update:modelValue', value);
+      this.switchList();
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
Также сделал доп. задание: скрытый селект реагирующий на изменение `props.modelValue` и отсылающий событие `update:modelValue` при изменении скрытого селекта.

Для чего нужен скрытый селект в этой задаче? Если бы список опций отображался при помощи тега select с аналогичным поведением, это бы имело смысл. А так мы имеем параллельно бегущий DOM элемент с аналогичной функциональностью.